### PR TITLE
Add links to chart dirs in cilium/cilium repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 This repository holds helm templates for the following releases:
 
-* [v1.7.0](https://github.com/cilium/cilium/releases/tag/v1.7.0)
-* [v1.7.0-rc4](https://github.com/cilium/cilium/releases/tag/v1.7.0-rc4)
-* [v1.7.0-rc3](https://github.com/cilium/cilium/releases/tag/v1.7.0-rc3)
-* [v1.6.6](https://github.com/cilium/cilium/releases/tag/v1.6.6)
-* [v1.6.5](https://github.com/cilium/cilium/releases/tag/v1.6.5)
+* [v1.7.0](https://github.com/cilium/cilium/releases/tag/v1.7.0) (_[source](https://github.com/cilium/cilium/tree/v1.7.0/install/kubernetes/cilium)_)
+* [v1.7.0-rc4](https://github.com/cilium/cilium/releases/tag/v1.7.0-rc4) (_[source](https://github.com/cilium/cilium/tree/v1.7.0-rc4/install/kubernetes/cilium)_)
+* [v1.7.0-rc3](https://github.com/cilium/cilium/releases/tag/v1.7.0-rc3) (_[source](https://github.com/cilium/cilium/tree/v1.7.0-rc3/install/kubernetes/cilium)_)
+* [v1.6.6](https://github.com/cilium/cilium/releases/tag/v1.6.6) (_[source](https://github.com/cilium/cilium/tree/v1.6.6/install/kubernetes/cilium)_)
+* [v1.6.5](https://github.com/cilium/cilium/releases/tag/v1.6.5) (_[source](https://github.com/cilium/cilium/tree/v1.6.5/install/kubernetes/cilium)_)
 
 The following releases point to the latest unreleased commit of the following branches:
 
-* [v1.6-dev](https://github.com/cilium/cilium/tree/v1.6)
+* [v1.6-dev](https://github.com/cilium/cilium/tree/v1.6) (_[source](https://github.com/cilium/cilium/tree/v1.6/install/kubernetes/cilium)_)


### PR DESCRIPTION
While looking at this repo I found it wasn't clear where the charts live, so I added some links.