### PR TITLE
Fix up release dates in artifact prepare script

### DIFF
--- a/fix_dates.sh
+++ b/fix_dates.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eo pipefail
+
+linesWithDate=($(git blame index.yaml --date=iso-strict \
+                 | awk '/created/ { print $5; }' \
+                 | sed 's/)$//'))
+
+# Lines with the date were overwritten. Take an adjacent line for real date.
+dates=($(git blame index.yaml --date=iso-strict \
+         | grep -A 1 created \
+         | grep -v created \
+         | awk '{ print $4 }'))
+
+for i in ${!linesWithDate[@]}; do
+    if ! date --date ${dates[$i]} >/dev/null; then
+        >&2 echo "unclean git tree, stash all changes before running this script."
+        exit 1
+    fi
+
+    sed -i "${linesWithDate[$i]}s/\"[^\"]*\"/\"${dates[$i]}\"/" index.yaml
+done

--- a/index.yaml
+++ b/index.yaml
@@ -3,7 +3,7 @@ entries:
   cilium:
   - apiVersion: v2
     appVersion: 1.9.0
-    created: "2020-11-10T17:19:32.917806406+01:00"
+    created: "2020-11-10T17:16:14+01:00"
     description: Helm chart for Cilium
     digest: 7aaa0ccc7ca58ecaa72f063be7553799cdc9357c7f96de2bdf052d2d551385ec
     home: https://cilium.io/
@@ -15,7 +15,7 @@ entries:
     version: 1.9.0
   - apiVersion: v2
     appVersion: 1.9.0-rc3
-    created: "2020-11-10T17:19:32.911521878+01:00"
+    created: "2020-11-02T16:47:36-08:00"
     description: Helm chart for Cilium
     digest: b590c586d184ecd431d34a741cb61604cc58677f1835fa709ccc3f89c7b15226
     home: https://cilium.io/
@@ -27,7 +27,7 @@ entries:
     version: 1.9.0-rc3
   - apiVersion: v2
     appVersion: 1.9.0-rc2
-    created: "2020-11-10T17:19:32.906572714+01:00"
+    created: "2020-10-19T16:44:31+02:00"
     description: Helm chart for Cilium
     digest: a6ea50230974af6d4661b0ab5fb5b6e9f19df6c981ba2b3341f7b6f03fe660a1
     home: https://cilium.io/
@@ -39,7 +39,7 @@ entries:
     version: 1.9.0-rc2
   - apiVersion: v2
     appVersion: 1.9.0-rc1
-    created: "2020-11-10T17:19:32.902565581+01:00"
+    created: "2020-10-12T18:49:21-07:00"
     description: Helm chart for Cilium
     digest: 8283ec0b063dd777d479045809994718f853628e9fcef24a36ccc2e6b8bd376c
     home: https://cilium.io/
@@ -51,7 +51,7 @@ entries:
     version: 1.9.0-rc1
   - apiVersion: v2
     appVersion: 1.9.0-rc0
-    created: "2020-11-10T17:19:32.897643915+01:00"
+    created: "2020-08-18T22:28:07+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -100,7 +100,7 @@ entries:
     version: 1.9.0-rc0
   - apiVersion: v2
     appVersion: 1.9-dev
-    created: "2020-11-10T17:19:32.893769916+01:00"
+    created: "2020-10-19T16:43:54+02:00"
     description: Helm chart for Cilium
     digest: 0e475ccaf626355dd5dc2fab7f40e3d1b47800778cb34337f7fa9a25918c48ed
     home: https://cilium.io/
@@ -112,7 +112,7 @@ entries:
     version: 1.9-dev
   - apiVersion: v1
     appVersion: 1.8.5
-    created: "2020-11-10T17:19:32.888434637+01:00"
+    created: "2020-10-28T16:30:24-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -161,7 +161,7 @@ entries:
     version: 1.8.5
   - apiVersion: v1
     appVersion: 1.8.4
-    created: "2020-11-10T17:19:32.881789954+01:00"
+    created: "2020-09-30T17:51:09-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -210,7 +210,7 @@ entries:
     version: 1.8.4
   - apiVersion: v1
     appVersion: 1.8.3
-    created: "2020-11-10T17:19:32.87676235+01:00"
+    created: "2020-09-04T15:09:39+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -259,7 +259,7 @@ entries:
     version: 1.8.3
   - apiVersion: v1
     appVersion: 1.8.2
-    created: "2020-11-10T17:19:32.873669191+01:00"
+    created: "2020-07-23T16:13:58-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -308,7 +308,7 @@ entries:
     version: 1.8.2
   - apiVersion: v1
     appVersion: 1.8.1
-    created: "2020-11-10T17:19:32.868645949+01:00"
+    created: "2020-07-02T21:45:34+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -357,7 +357,7 @@ entries:
     version: 1.8.1
   - apiVersion: v1
     appVersion: 1.8.0
-    created: "2020-11-10T17:19:32.864227902+01:00"
+    created: "2020-06-22T17:52:19+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -406,7 +406,7 @@ entries:
     version: 1.8.0
   - apiVersion: v1
     appVersion: 1.8.0-rc4
-    created: "2020-11-10T17:19:32.86048251+01:00"
+    created: "2020-06-19T13:10:57-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -455,7 +455,7 @@ entries:
     version: 1.8.0-rc4
   - apiVersion: v1
     appVersion: 1.8.0-rc3
-    created: "2020-11-10T17:19:32.857650965+01:00"
+    created: "2020-06-15T17:14:52+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -504,7 +504,7 @@ entries:
     version: 1.8.0-rc3
   - apiVersion: v1
     appVersion: 1.8.0-rc2
-    created: "2020-11-10T17:19:32.854048892+01:00"
+    created: "2020-05-29T15:59:58-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -557,7 +557,7 @@ entries:
     version: 1.8.0-rc2
   - apiVersion: v1
     appVersion: 1.8.0-rc1
-    created: "2020-11-10T17:19:32.851007941+01:00"
+    created: "2020-05-21T15:03:34-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -606,7 +606,7 @@ entries:
     version: 1.8.0-rc1
   - apiVersion: v1
     appVersion: 1.8-dev
-    created: "2020-11-10T17:19:32.848313663+01:00"
+    created: "2020-06-22T18:37:46+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -655,7 +655,7 @@ entries:
     version: 1.8-dev
   - apiVersion: v1
     appVersion: 1.7.11
-    created: "2020-11-10T17:19:32.82267507+01:00"
+    created: "2020-10-27T18:55:05-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -691,7 +691,7 @@ entries:
     version: 1.7.11
   - apiVersion: v1
     appVersion: 1.7.10
-    created: "2020-11-10T17:19:32.820450625+01:00"
+    created: "2020-09-30T17:01:58-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -727,7 +727,7 @@ entries:
     version: 1.7.10
   - apiVersion: v1
     appVersion: 1.7.9
-    created: "2020-11-10T17:19:32.844257519+01:00"
+    created: "2020-09-01T20:25:45-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -763,7 +763,7 @@ entries:
     version: 1.7.9
   - apiVersion: v1
     appVersion: 1.7.8
-    created: "2020-11-10T17:19:32.842133974+01:00"
+    created: "2020-08-28T13:38:04-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -799,7 +799,7 @@ entries:
     version: 1.7.8
   - apiVersion: v1
     appVersion: 1.7.7
-    created: "2020-11-10T17:19:32.83926042+01:00"
+    created: "2020-08-04T18:44:45-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -835,7 +835,7 @@ entries:
     version: 1.7.7
   - apiVersion: v1
     appVersion: 1.7.6
-    created: "2020-11-10T17:19:32.836206294+01:00"
+    created: "2020-07-02T14:58:08-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -871,7 +871,7 @@ entries:
     version: 1.7.6
   - apiVersion: v1
     appVersion: 1.7.5
-    created: "2020-11-10T17:19:32.833251452+01:00"
+    created: "2020-06-12T15:00:23+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -907,7 +907,7 @@ entries:
     version: 1.7.5
   - apiVersion: v1
     appVersion: 1.7.4
-    created: "2020-11-10T17:19:32.830013757+01:00"
+    created: "2020-05-15T15:12:07-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -943,7 +943,7 @@ entries:
     version: 1.7.4
   - apiVersion: v1
     appVersion: 1.7.3
-    created: "2020-11-10T17:19:32.826189509+01:00"
+    created: "2020-04-29T16:14:35-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -979,7 +979,7 @@ entries:
     version: 1.7.3
   - apiVersion: v1
     appVersion: 1.7.2
-    created: "2020-11-10T17:19:32.824447057+01:00"
+    created: "2020-04-03T12:28:11-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1015,7 +1015,7 @@ entries:
     version: 1.7.2
   - apiVersion: v1
     appVersion: 1.7.1
-    created: "2020-11-10T17:19:32.816151085+01:00"
+    created: "2020-03-04T15:52:49-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1051,7 +1051,7 @@ entries:
     version: 1.7.1
   - apiVersion: v1
     appVersion: 1.7.0
-    created: "2020-11-10T17:19:32.814292442+01:00"
+    created: "2020-02-18T17:31:32-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1087,7 +1087,7 @@ entries:
     version: 1.7.0
   - apiVersion: v1
     appVersion: 1.7.0-rc4
-    created: "2020-11-10T17:19:32.812309067+01:00"
+    created: "2020-02-12T16:31:15-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1123,7 +1123,7 @@ entries:
     version: 1.7.0-rc4
   - apiVersion: v1
     appVersion: 1.7.0-rc3
-    created: "2020-11-10T17:19:32.810278091+01:00"
+    created: "2020-02-04T11:22:10-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1159,7 +1159,7 @@ entries:
     version: 1.7.0-rc3
   - apiVersion: v1
     appVersion: 1.7-dev
-    created: "2020-11-10T17:19:32.805562326+01:00"
+    created: "2020-02-19T09:16:25+01:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1195,7 +1195,7 @@ entries:
     version: 1.7-dev
   - apiVersion: v1
     appVersion: 1.6.12
-    created: "2020-11-10T17:19:32.778421556+01:00"
+    created: "2020-09-30T17:01:49-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1231,7 +1231,7 @@ entries:
     version: 1.6.12
   - apiVersion: v1
     appVersion: 1.6.11
-    created: "2020-11-10T17:19:32.775601013+01:00"
+    created: "2020-08-03T16:53:07-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1267,7 +1267,7 @@ entries:
     version: 1.6.11
   - apiVersion: v1
     appVersion: 1.6.10
-    created: "2020-11-10T17:19:32.773875298+01:00"
+    created: "2020-07-02T20:16:39+02:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1303,7 +1303,7 @@ entries:
     version: 1.6.10
   - apiVersion: v1
     appVersion: 1.6.9
-    created: "2020-11-10T17:19:32.800582116+01:00"
+    created: "2020-06-05T16:58:12-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1339,7 +1339,7 @@ entries:
     version: 1.6.9
   - apiVersion: v1
     appVersion: 1.6.8
-    created: "2020-11-10T17:19:32.798575981+01:00"
+    created: "2020-03-25T15:02:28-07:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1375,7 +1375,7 @@ entries:
     version: 1.6.8
   - apiVersion: v1
     appVersion: 1.6.7
-    created: "2020-11-10T17:19:32.79457097+01:00"
+    created: "2020-03-04T15:08:04-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1411,7 +1411,7 @@ entries:
     version: 1.6.7
   - apiVersion: v1
     appVersion: 1.6.6
-    created: "2020-11-10T17:19:32.791549738+01:00"
+    created: "2020-02-03T15:14:02-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1447,7 +1447,7 @@ entries:
     version: 1.6.6
   - apiVersion: v1
     appVersion: 1.6.5
-    created: "2020-11-10T17:19:32.786863108+01:00"
+    created: "2020-01-23T10:16:22-08:00"
     dependencies:
     - condition: agent.enabled
       name: agent
@@ -1483,7 +1483,7 @@ entries:
     version: 1.6.5
   - apiVersion: v1
     appVersion: 1.6-dev
-    created: "2020-11-10T17:19:32.772072543+01:00"
+    created: "2020-02-11T15:01:31+01:00"
     dependencies:
     - condition: agent.enabled
       name: agent

--- a/prepare_artifacts.sh
+++ b/prepare_artifacts.sh
@@ -16,7 +16,8 @@ if [ ! -e $CILIUM_DIR/install/kubernetes/cilium/values.yaml ]; then
 	exit 1
 fi
 
-VERSION=$(cat $CILIUM_DIR/VERSION)
+CHART_PATH="$CILIUM_DIR/install/kubernetes/cilium/Chart.yaml"
+VERSION="$(awk '/version:/ { print $2; exit; } ' $CHART_PATH)"
 cd $CILIUM_DIR/install/kubernetes
 helm package --destination "$CWD" cilium
 cd -

--- a/prepare_artifacts.sh
+++ b/prepare_artifacts.sh
@@ -25,3 +25,6 @@ helm repo index . --merge index.yaml
 $EDITOR README.md
 git add README.md index.yaml cilium-$VERSION.tgz
 git commit -s -m "Add $VERSION@$(cd $CILIUM_DIR; git rev-parse HEAD) ⎈"
+./fix_dates.sh
+git add index.yaml
+git commit --amend


### PR DESCRIPTION
Fix up the release dates and add a step that ensures they stay fixed over time.

This should fix up how the chart versions appear to have all been released on the same day at https://artifacthub.io/packages/helm/cilium/cilium .