### PR TITLE
CI improvements re. cilium-cli

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -162,8 +162,7 @@ jobs:
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide -v=6
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -146,16 +146,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.8.* ]]; then
-            kubectl apply \
-              -f "https://raw.githubusercontent.com/cilium/cilium/${{ steps.vars.outputs.chartVersion }}/examples/kubernetes/connectivity-check/connectivity-check.yaml"
-            # wait for all pods in the default namespace since cilium-cli
-            # does not support connectivity test in 1.8
-            # can be removed once cilium-cli 0.8.5 is released
-            kubectl wait pod -n default --for=condition=Ready --timeout=300s -l k8s!=all
-          else
-            cilium connectivity test
-          fi
+          cilium connectivity test
 
       - name: Post-test information gathering
         if: ${{ failure() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -46,8 +46,10 @@ jobs:
       - name: Install Cilium CLI
         run: |
           curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
-          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
-          rm cilium-linux-amd64.tar.gz
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@04141d8a7edfc8c679682f23e7bbbe05cbe32bb3


### PR DESCRIPTION
* verify cilium-cli tarball sha256sum
* use `cilium sysdump` in GKE conformance test
* use `cilium connectivity test` on 1.8 releases

See individual commit messages for further details.