### PR TITLE
Fix Cilium GKE workflow

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -9,6 +9,8 @@ on:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  # https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+  USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
   installation-and-connectivity:
@@ -18,6 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up job variables
@@ -51,16 +54,24 @@ jobs:
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
           rm cilium-linux-amd64.tar.gz{,.sha256sum}
 
+      - name: Set up gcloud credentials
+        id: 'auth'
+        uses: 'google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712'
+        with:
+          credentials_json: '${{ secrets.GCP_PR_SA_KEY }}'
+
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_PR_SA_KEY }}
-          export_default_credentials: true
 
       - name: Display gcloud CLI info
         run: |
           gcloud info
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Create GKE cluster
         run: |
@@ -98,7 +109,8 @@ jobs:
           echo "NATIVE_CIDR $NATIVE_CIDR"
           helm repo add cilium https://helm.cilium.io
           helm repo update
-          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.12.* ]]; then
+          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.12.* || \
+                ${{ steps.vars.outputs.chartVersion }} == 1.13.* ]]; then
             helm install cilium cilium/cilium --version ${{ steps.vars.outputs.chartVersion }} \
               --namespace kube-system \
               --set nodeinit.enabled=true \
@@ -156,6 +168,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
+          cilium status --wait
           cilium connectivity test
 
       - name: Post-test information gathering


### PR DESCRIPTION
- Set fetch-depth to zero to fetch all history.
- Use google-github-actions/auth to get rid of the warning.
- Use gke-gcloud-auth-plugin.
- Handle Cilium chart version 1.13.*.
- Run "cilium status --wait" before starting the connectivity test.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>