### PR TITLE
.github: clean up conformance-gke workflow

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -75,29 +75,16 @@ jobs:
 
       - name: Create GKE cluster
         run: |
-          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.9.* || \
-                  ${{ steps.vars.outputs.chartVersion }} == 1.8.* ]]; then
-            gcloud container clusters create ${{ env.clusterName }} \
-              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-              --zone ${{ env.zone }} \
-              --image-type COS_CONTAINERD \
-              --num-nodes 2 \
-              --machine-type e2-custom-2-4096 \
-              --disk-type pd-standard \
-              --disk-size 10GB \
-              --preemptible
-          else
-            gcloud container clusters create ${{ env.clusterName }} \
-              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-              --zone ${{ env.zone }} \
-              --image-type COS_CONTAINERD \
-              --num-nodes 2 \
-              --machine-type e2-custom-2-4096 \
-              --disk-type pd-standard \
-              --disk-size 10GB \
-              --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
-              --preemptible
-          fi
+          gcloud container clusters create ${{ env.clusterName }} \
+            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --zone ${{ env.zone }} \
+            --image-type COS_CONTAINERD \
+            --num-nodes 2 \
+            --machine-type e2-custom-2-4096 \
+            --disk-type pd-standard \
+            --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --preemptible
 
       - name: Get cluster credentials
         run: |
@@ -109,18 +96,7 @@ jobs:
           echo "NATIVE_CIDR $NATIVE_CIDR"
           helm repo add cilium https://helm.cilium.io
           helm repo update
-          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.12.* || \
-                ${{ steps.vars.outputs.chartVersion }} == 1.13.* ]]; then
-            helm install cilium cilium/cilium --version ${{ steps.vars.outputs.chartVersion }} \
-              --namespace kube-system \
-              --set nodeinit.enabled=true \
-              --set nodeinit.reconfigureKubelet=true \
-              --set nodeinit.removeCbrBridge=true \
-              --set cni.binPath=/home/kubernetes/bin \
-              --set gke.enabled=true \
-              --set ipam.mode=kubernetes \
-              --set ipv4NativeRoutingCIDR="${NATIVE_CIDR}"
-          elif [[ ${{ steps.vars.outputs.chartVersion }} == 1.11.* ]]; then
+          if [[ ${{ steps.vars.outputs.chartVersion }} == 1.11.* ]]; then
             helm install cilium cilium/cilium --version ${{ steps.vars.outputs.chartVersion }} \
               --namespace kube-system \
               --set nodeinit.enabled=true \
@@ -140,30 +116,16 @@ jobs:
               --set gke.enabled=true \
               --set ipam.mode=kubernetes \
               --set nativeRoutingCIDR="${NATIVE_CIDR}"
-          elif [[ ${{ steps.vars.outputs.chartVersion }} == 1.9.* ]]; then
+          else
             helm install cilium cilium/cilium --version ${{ steps.vars.outputs.chartVersion }} \
               --namespace kube-system \
               --set nodeinit.enabled=true \
               --set nodeinit.reconfigureKubelet=true \
-              --set nodeinit.restartPods=true \
               --set nodeinit.removeCbrBridge=true \
               --set cni.binPath=/home/kubernetes/bin \
               --set gke.enabled=true \
               --set ipam.mode=kubernetes \
-              --set nativeRoutingCIDR="${NATIVE_CIDR}"
-              kubectl wait -n kube-system pod -l k8s-app=cilium --for=condition=Ready --timeout=300s
-          elif [[ ${{ steps.vars.outputs.chartVersion }} == 1.8.* ]]; then
-            helm install cilium cilium/cilium --version ${{ steps.vars.outputs.chartVersion }} \
-              --namespace kube-system \
-              --set global.nodeinit.enabled=true \
-              --set nodeinit.reconfigureKubelet=true \
-              --set nodeinit.restartPods=true \
-              --set nodeinit.removeCbrBridge=true \
-              --set global.cni.binPath=/home/kubernetes/bin \
-              --set global.gke.enabled=true \
-              --set config.ipam=kubernetes \
-              --set global.nativeRoutingCIDR="${NATIVE_CIDR}"
-              kubectl wait -n kube-system pod -l k8s-app=cilium --for=condition=Ready --timeout=300s
+              --set ipv4NativeRoutingCIDR="${NATIVE_CIDR}"
           fi
 
       - name: Run connectivity test


### PR DESCRIPTION
- remove deprecated 1.9 and 1.8 Cilium versions
- remove and special installation steps individual Cilium versions since they all run with the same steps since Cilium 1.10

Signed-off-by: André Martins <andre@cilium.io>