### PR TITLE
Change GKE cluster creation

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -78,13 +78,16 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
-            --disk-size 10GB \
+            --disk-size 20GB \
             --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
-            --preemptible
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
This PR aligns GKE cluster creation with the cilium repository standards, resolving network exhaustion issues in workflow runs.