### PR TITLE
generate_readme.sh: Fix sed command for macOS

### DIFF
--- a/generate_readme.sh
+++ b/generate_readme.sh
@@ -11,7 +11,7 @@ for version in \
     $(find -- * -name 'cilium-*.tgz' ! -name "*dev*" \
     | cut -d - -f 2- \
     | xargs basename -s .tgz \
-    | sed '/-/!{s/$/_/}' \
+    | sed '/-/!{s/$/_/;}' \
     | sort -Vr \
     | sed 's/_$//'); do
   echo "* [v$version](https://github.com/cilium/cilium/releases/tag/v$version) (_[source](https://github.com/cilium/cilium/tree/v$version/install/kubernetes/cilium)_)"
@@ -27,7 +27,7 @@ for version in \
     $(find -- * -name 'tetragon-*.tgz' ! -name "*dev*" \
     | cut -d - -f 2- \
     | xargs basename -s .tgz \
-    | sed '/-/!{s/$/_/}' \
+    | sed '/-/!{s/$/_/;}' \
     | sort -Vr \
     | sed 's/_$//'); do
   # Tetragon chart was moved in 1.1 release


### PR DESCRIPTION
tested manually by running:
```
% ./generate_readme.sh > README.md
% git diff
%
```
on both linux and macOS. without this patch, generate_readme.sh fails on macOS with this error:
```
% ./generate_readme.sh > README.md
sed: 1: "/-/!{s/$/_/}": bad flag in substitute command: '}'
xargs: basename: terminated with signal 13; aborting
sed: 1: "/-/!{s/$/_/}": bad flag in substitute command: '}'
xargs: basename: terminated with signal 13; aborting
```

ref: https://stackoverflow.com/q/75003095