### PR TITLE
Correctly specify the chart version to pull

### DIFF
--- a/.github/workflows/validate-cilium-chart.yaml
+++ b/.github/workflows/validate-cilium-chart.yaml
@@ -35,7 +35,8 @@ jobs:
               # Download the chart from the Helm repository on push.
               helm repo add cilium https://helm.cilium.io
               helm repo update
-              until helm pull cilium/cilium -d tmp --version ${{ steps.vars.outputs.chartVersion }}
+              mkdir tmp
+              until helm pull cilium/cilium -d tmp --version "${chart_version}"
               do
                 echo "helm pull failed. Retrying..."
                 sleep 1


### PR DESCRIPTION
There is no ${{ steps.vars.outputs.chartVersion }}. Also create the tmp directory before running helm pull.

Fixes: 3a7f889089aa9 ("Validate Helm chart")