### PR TITLE
Rerun "helm repo update" if "helm pull" fails

### DIFF
--- a/.github/workflows/validate-cilium-chart.yaml
+++ b/.github/workflows/validate-cilium-chart.yaml
@@ -40,6 +40,7 @@ jobs:
               do
                 echo "helm pull failed. Retrying..."
                 sleep 1
+                helm repo update
               done
               echo "chartPath=tmp/cilium-${chart_version}.tgz" >> $GITHUB_OUTPUT
             fi


### PR DESCRIPTION
Kudos to Helm for suggesting the fix in the error message:

    Error: chart "cilium" matching 1.16.0-pre.3 not found in cilium index. (try 'helm repo update')