### PR TITLE
switch cosign registry from GCR to GHCR

### DIFF
--- a/generate_helm_release.sh
+++ b/generate_helm_release.sh
@@ -7,7 +7,7 @@ DOCKER=${DOCKER:-docker}
 ORG=${ORG:-cilium}
 
 cosign() {
-  "${DOCKER}" run --rm gcr.io/projectsigstore/cosign:v2.2.4 "$@"
+  "${DOCKER}" run --rm ghcr.io/sigstore/cosign/cosign:v2.2.4 "$@"
 }
 
 helm() {


### PR DESCRIPTION
This changes the script to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.