### PR TITLE
generate_helm_release: use -B for checkout

### DIFF
--- a/generate_helm_release.sh
+++ b/generate_helm_release.sh
@@ -51,7 +51,7 @@ main() {
         git stash
         remote=$(git remote -v | grep "${ORG}/${PROJECT}" | awk '{print $1;exit}')
         git fetch "${remote}"
-        git checkout -b "$version"
+        git checkout -B "$version"
         cd -
     else
         git clone --depth 1 --branch "$version" "https://github.com/cilium/${PROJECT}.git"


### PR DESCRIPTION
use git checkout -B so that checkout does not fail if the branch exists already.