### PR TITLE
generate_helm_release: Fix cached repo dir

### DIFF
--- a/generate_helm_release.sh
+++ b/generate_helm_release.sh
@@ -51,7 +51,7 @@ main() {
         git stash
         remote=$(git remote -v | grep "${ORG}/${PROJECT}" | awk '{print $1;exit}')
         git fetch "${remote}"
-        git checkout -B "$version"
+        git checkout "$version"
         cd -
     else
         git clone --depth 1 --branch "$version" "https://github.com/cilium/${PROJECT}.git"


### PR DESCRIPTION
If a release manager had previously tagged a release, then they would have
already checkout out a copy of the target project into the local directory. In
this scenario however the checkout command attempted to create a new branch
with the name of the new release, but the content of the branch would be the
currently checked out SHA.

This branch requires that the upstream project has already tagged the target
release and that this repo is just pulling that target version in order to
generate the Helm release.

Fixes an issue where the command fails with a file not found error if run in a
directory where the target project directory was already checked out to an
earlier git SHA:


``` ./generate_helm_release.sh cilium v1.18.0-pre.2 ... mv: cannot stat
'cilium/install/kubernetes/cilium-1.18.0-pre.2.tgz': No such file or directory
```

Fixes: a9d85774177e ("generate_helm_release: use -B for checkout")
