### PR TITLE
.github: Check Cilium charts via kind deployment

### DIFF
--- a/.github/workflows/validate-cilium-chart.yaml
+++ b/.github/workflows/validate-cilium-chart.yaml
@@ -21,10 +21,13 @@ jobs:
         id: vars
         run: |
           # Get last commit message
-          readonly local last_commit_log=$(git log -1 --grep "^Add cilium" --pretty=format:"%s")
+          readonly local last_commit_log=$(git log -1 --grep "^Add cilium" \
+                                                      --pretty=format:"%s")
           echo "last commit log: $last_commit_log"
 
-          readonly local chart_version=$(echo "$last_commit_log" | grep -Eo "Add cilium v[^@]+" | sed 's/Add\ cilium\ v//' )
+          readonly local chart_version=$(echo "$last_commit_log" \
+                                         | grep -Eo "Add cilium v[^@]+" \
+                                         | sed 's/Add\ cilium\ v//' )
           echo "Helm chart detected version: '${chart_version}'"
 
           if [[ -n "${chart_version}" ]]; then

--- a/.github/workflows/validate-cilium-chart.yaml
+++ b/.github/workflows/validate-cilium-chart.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 6
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -53,3 +53,51 @@ jobs:
         if: ${{ steps.vars.outputs.chartPath != '' }}
         run: |
           ./validate_helm_chart.sh ${{ steps.vars.outputs.chartPath }}
+
+      - name: Install Cilium CLI
+        if: ${{ steps.vars.outputs.chartPath != '' }}
+        run: |
+          curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar -xzvf cilium-linux-amd64.tar.gz -C /usr/local/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+
+      - name: Download kind-config.yaml
+        if: ${{ steps.vars.outputs.chartPath != '' }}
+        run: |
+          curl -LO https://raw.githubusercontent.com/cilium/cilium/main/.github/kind-config.yaml
+
+      - name: Create k8s Kind Cluster
+        if: ${{ steps.vars.outputs.chartPath != '' }}
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          config: kind-config.yaml
+
+      - name: Install Cilium
+        if: ${{ steps.vars.outputs.chartPath != '' }}
+        run: |
+          helm install cilium ./${{ steps.vars.outputs.chartPath }} \
+              --version "${{ steps.vars.outputs.chartVersion }}" \
+              --namespace kube-system
+
+      - name: Check Cilium Status
+        if: ${{ steps.vars.outputs.chartPath != '' }}
+        run: |
+          cilium status --wait --wait-duration 1m --interactive=false
+
+      - name: Post-test information gathering
+        if: ${{ failure() }}
+        run: |
+          cilium status
+          kubectl get pods --all-namespaces -o wide -v=6
+          cilium sysdump --output-filename cilium-sysdump-out
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+      - name: Upload artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip
+          retention-days: 5


### PR DESCRIPTION
During the 2025-05 releases v1.15.7, v1.16.10, v1.17.4 the Helm charts
were incorrectly generated, causing install problems for the new release
versions. To mitigate this issue, extend the current GitHub workflow to
deploy Cilium into a kind cluster and fail if the deployment fails.
While this will not directly address the underlying problem that caused
incorrect generation of Helm charts, it should signal to release
managers that mitigating action must be taken to ensure the released
artifacts work correctly.

Based on intermediate prior work by @michi-covalent [here](https://github.com/cilium/charts/actions/runs/9182260367/workflow?pr=125) as part of #125 .

Related: https://github.com/cilium/charts/pull/174#issuecomment-2885163485

Example failure via #176: https://github.com/cilium/charts/actions/runs/15478848632/job/43580545415?pr=176#step:9:31