### PR TITLE
dependabot: Remove unused labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,3 @@ updates:
       interval: daily
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
-    labels:
-    - kind/enhancement
-    - release-note/misc


### PR DESCRIPTION
These two labels don't exist on the cilium/charts repository.

Signed-off-by: Joe Stringer <joe@cilium.io>
