### PR TITLE
Trying to fix GKE v2

### DIFF
--- a/.github/workflows/conformance-tetragon-gke.yaml
+++ b/.github/workflows/conformance-tetragon-gke.yaml
@@ -6,6 +6,14 @@ on:
     branches:
       - master
 
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a


### PR DESCRIPTION
This patch fixes permissions to fix:
Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job.

Based on https://github.com/google-github-actions/auth#usage it seems that we need contents and id-token.

This is also the case in cilium: https://github.com/cilium/cilium/blob/3eea62d7dafe2c6c4da849de48194010795fee2b/.github/workflows/conformance-gke.yaml#L27-L39