### PR TITLE
shell: Apply common linter fixes

### DIFF
--- a/generate_helm_release.sh
+++ b/generate_helm_release.sh
@@ -39,7 +39,7 @@ symbolic_ref() {
 main() {
     PROJECT="$1"
     version="$2"
-    ersion="$(echo $version | sed -e 's/^v//')"
+    ersion="${version/v/}"
 
     if [ "$PROJECT" != cilium  ] && [ "$PROJECT" != "tetragon" ] ; then
         echo "bad project $PROJECT"
@@ -57,7 +57,7 @@ main() {
     default_branch=$(symbolic_ref "refs/remotes/${remote}/HEAD" "${remote}")
     if [ "$(symbolic_ref HEAD "${remote}")" !=  "${default_branch}" ]; then
         git stash
-        git checkout $default_branch
+        git checkout "$default_branch"
         git fetch "${remote}"
         git merge --ff-only "${remote}/${default_branch}"
     fi
@@ -108,7 +108,7 @@ main() {
     mv "${chart_dir}/${PROJECT}-${ersion}".tgz "${chart_dir}/index.yaml" "${CWD}"
     ./generate_readme.sh > README.md
     git add README.md index.yaml "${PROJECT}-${ersion}".tgz
-    git commit -s -m "Add ${PROJECT} $version@$(cd ${PROJECT}; git rev-parse HEAD) ⎈"
+    git commit -s -m "Add ${PROJECT} $version@$(cd "${PROJECT}"; git rev-parse HEAD) ⎈"
 }
 
 main "$@"

--- a/generate_readme.sh
+++ b/generate_readme.sh
@@ -34,10 +34,8 @@ for version in \
   TETRAGON_CHART_DIR="install/kubernetes/tetragon"
   MAJOR=$(echo "$version" | cut -d. -f1)
   MINOR=$(echo "$version" | cut -d. -f2)
-  if [ "$MAJOR" -lt 1 ] || ([ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 1 ]); then
+  if [ "$MAJOR" -lt 1 ] || { [ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 1 ]; }; then
     TETRAGON_CHART_DIR="install/kubernetes"
   fi
   echo "* [v$version](https://github.com/cilium/tetragon/releases/tag/v$version) (_[source](https://github.com/cilium/tetragon/tree/v$version/$TETRAGON_CHART_DIR)_)"
 done
-
-cat << EOF

--- a/validate_helm_chart.sh
+++ b/validate_helm_chart.sh
@@ -50,6 +50,7 @@ TETRAGON_IMAGE_PATHS=(
 # $1 - Helm chart tgz file or OCI chart reference
 main() {
   CHART="$1"
+  declare -a HELM_ARGS
 
   if [ -z "$CHART" ]; then
       echo "ERROR: Chart argument is required"
@@ -74,15 +75,14 @@ main() {
           exit 1
       fi
 
-      CHART_REF="$OCI_BASE"
-      VERSION_FLAG="--version $OCI_VERSION"
+      HELM_ARGS+=("$OCI_BASE")
+      HELM_ARGS+=("--version" "$OCI_VERSION")
   else
-      CHART_REF="$CHART"
-      VERSION_FLAG=""
+      HELM_ARGS+=("$CHART")
   fi
 
-  APP=$(helm show chart $VERSION_FLAG "$CHART_REF" | yq e '.name' -)
-  CHART_VERSION=$(helm show chart $VERSION_FLAG "$CHART_REF" | yq e '.version' -)
+  APP=$(helm show chart "${HELM_ARGS[@]}" | yq e '.name' -)
+  CHART_VERSION=$(helm show chart "${HELM_ARGS[@]}" | yq e '.version' -)
   if [ "$APP" == "cilium" ]; then
     IMAGE_PATHS=("${CILIUM_IMAGE_PATHS[@]}")
   elif [ "$APP" == "tetragon" ]; then
@@ -93,7 +93,7 @@ main() {
   fi
 
   for path in "${IMAGE_PATHS[@]}"; do
-    tag=$(helm show values $VERSION_FLAG --jsonpath "$path" "$CHART_REF")
+    tag=$(helm show values "${HELM_ARGS[@]}" --jsonpath "$path")
     if [ "$tag" == "v$CHART_VERSION" ]; then
       echo "SUCCESS: $APP $path=$tag matches chart version $CHART_VERSION"
     else


### PR DESCRIPTION
Lint for unnecessary subshells and commands, variable double-quoting to
avoid globbing, and drop the unterminated cat command at the end of
readme generation.